### PR TITLE
Allow InstancePerRequest dependencies

### DIFF
--- a/Source/SignalR.Extras.Autofac/LifetimeHubManager.cs
+++ b/Source/SignalR.Extras.Autofac/LifetimeHubManager.cs
@@ -15,7 +15,7 @@ namespace SignalR.Extras.Autofac
 		public T ResolveHub<T>(Type type, ILifetimeScope lifetimeScope)
 			where T : ILifetimeHub
 		{
-			var scope = lifetimeScope.BeginLifetimeScope();
+			var scope = lifetimeScope.BeginLifetimeScope(ScopeLifetimeTag.RequestLifetimeScopeTag);
 			var hub = (T)scope.Resolve(type);
 			hub.OnDisposing += HubOnDisposing;
 			_hubLifetimeScopes.TryAdd(hub, scope);

--- a/Source/SignalR.Extras.Autofac/ScopeLifetimeTag.cs
+++ b/Source/SignalR.Extras.Autofac/ScopeLifetimeTag.cs
@@ -1,0 +1,10 @@
+﻿namespace SignalR.Extras.Autofac
+{
+	public class ScopeLifetimeTag
+	{
+		/// <summary>
+		/// Tag used in setting up per-request lifetime scope registrations
+		/// </summary>
+		public static readonly object RequestLifetimeScopeTag = (object)"SignalRHub";
+	}
+}

--- a/Source/SignalR.Extras.Autofac/SignalR.Extras.Autofac.csproj
+++ b/Source/SignalR.Extras.Autofac/SignalR.Extras.Autofac.csproj
@@ -75,6 +75,7 @@
     <Compile Include="LifetimeHub.cs" />
     <Compile Include="RegisterExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScopeLifetimeTag.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Tests/SignalR.Extras.Autofac.Test/LifetimeHubFacts.cs
+++ b/Tests/SignalR.Extras.Autofac.Test/LifetimeHubFacts.cs
@@ -93,12 +93,14 @@ namespace SignalR.Extras.Autofac.Test
 			using (var hub2 = (DynamicLifetimeHubStub)hubManager.ResolveHub(nameof(DynamicLifetimeHubStub))) {
 				Assert.NotSame(hub1.ScopedDependency, hub2.ScopedDependency);
 				Assert.Same(hub1.SingletonDependency, hub2.SingletonDependency);
+				Assert.NotSame(hub1.RequestScopedDependency, hub2.RequestScopedDependency);
 			}
 
 			using (var hub1 = (GenericLifetimeHubStub)hubManager.ResolveHub(nameof(GenericLifetimeHubStub)))
 			using (var hub2 = (GenericLifetimeHubStub)hubManager.ResolveHub(nameof(GenericLifetimeHubStub))) {
 				Assert.NotSame(hub1.ScopedDependency, hub2.ScopedDependency);
 				Assert.Same(hub1.SingletonDependency, hub2.SingletonDependency);
+				Assert.NotSame(hub1.RequestScopedDependency, hub2.RequestScopedDependency);
 			}
 		}
 
@@ -111,16 +113,19 @@ namespace SignalR.Extras.Autofac.Test
 
 			int scopedDisposalCount = 0;
 			int singletonDisposalCount = 0;
+			int requestScopedDisposalCount = 0;
 			using (var hub = (DynamicLifetimeHubStub)hubManager.ResolveHub(nameof(DynamicLifetimeHubStub))) {
 				hub.ScopedDependency.OnDisposing += (s, a) => scopedDisposalCount++;
 				hub.SingletonDependency.OnDisposing += (s, a) => singletonDisposalCount++;
+				hub.RequestScopedDependency.OnDisposing += (s, a) => requestScopedDisposalCount++;
 			}
 
 			//The singleton dependency doesn't belong to the hub's scope
 			Assert.Equal(0, singletonDisposalCount);
 
-			//This dependency does and will be disposed when the hub is disposed
+			//These dependencies belong to the hub's scope and will be disposed when the hub is disposed
 			Assert.Equal(1, scopedDisposalCount);
+			Assert.Equal(1, requestScopedDisposalCount);
 		}
 
 
@@ -132,24 +137,27 @@ namespace SignalR.Extras.Autofac.Test
 
 			int scopedDisposalCount = 0;
 			int singletonDisposalCount = 0;
+			int requestScopedDisposalCount = 0;
 			using (var hub = (GenericLifetimeHubStub)hubManager.ResolveHub(nameof(GenericLifetimeHubStub))) {
 				hub.ScopedDependency.OnDisposing += (s, a) => scopedDisposalCount++;
 				hub.SingletonDependency.OnDisposing += (s, a) => singletonDisposalCount++;
+				hub.RequestScopedDependency.OnDisposing += (s, a) => requestScopedDisposalCount++;
 			}
 
 			//The singleton dependency doesn't belong to the hub's scope
 			Assert.Equal(0, singletonDisposalCount);
 
-			//This dependency does and will be disposed when the hub is disposed
+			//These dependencies belong to the hub's scope and will be disposed when the hub is disposed
 			Assert.Equal(1, scopedDisposalCount);
+			Assert.Equal(1, requestScopedDisposalCount);
 		}
 
 
 		[Fact]
 		public void UnmanagedLifetimeHubsDisposeWithoutThrowing()
 		{
-			new DynamicLifetimeHubStub(null, null).Dispose();
-			new GenericLifetimeHubStub(null, null).Dispose();
+			new DynamicLifetimeHubStub(null, null, null).Dispose();
+			new GenericLifetimeHubStub(null, null, null).Dispose();
 		}
 
 	}

--- a/Tests/SignalR.Extras.Autofac.Test/SignalR.Extras.Autofac.Test.csproj
+++ b/Tests/SignalR.Extras.Autofac.Test/SignalR.Extras.Autofac.Test.csproj
@@ -87,6 +87,7 @@
     <Compile Include="LifetimeHubManagerFacts.cs" />
     <Compile Include="LifetimeHubFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Stubs\Dependencies\RequestScopedObjectStub.cs" />
     <Compile Include="Stubs\GenericOrdinaryHubStub.cs" />
     <Compile Include="Stubs\DynamicOrdinaryHubStub.cs" />
     <Compile Include="TestHelper.cs" />

--- a/Tests/SignalR.Extras.Autofac.Test/Stubs/Dependencies/RequestScopedObjectStub.cs
+++ b/Tests/SignalR.Extras.Autofac.Test/Stubs/Dependencies/RequestScopedObjectStub.cs
@@ -1,0 +1,6 @@
+﻿namespace SignalR.Extras.Autofac.Test.Stubs.Dependencies
+{
+	public class RequestScopedObjectStub : ObjectStubBase
+	{
+	}
+}

--- a/Tests/SignalR.Extras.Autofac.Test/Stubs/DynamicLifetimeHubStub.cs
+++ b/Tests/SignalR.Extras.Autofac.Test/Stubs/DynamicLifetimeHubStub.cs
@@ -7,14 +7,16 @@ namespace SignalR.Extras.Autofac.Test.Stubs
 	public class DynamicLifetimeHubStub : LifetimeHub
 	{
 
-		public DynamicLifetimeHubStub(ScopedObjectStub dep1, SingletonObjectStub dep2)
+		public DynamicLifetimeHubStub(ScopedObjectStub dep1, SingletonObjectStub dep2, RequestScopedObjectStub dep3)
 		{
 			ScopedDependency = dep1;
 			SingletonDependency = dep2;
+			RequestScopedDependency = dep3;
 		}
 
 		public readonly ScopedObjectStub ScopedDependency;
 		public readonly SingletonObjectStub SingletonDependency;
+		public readonly RequestScopedObjectStub RequestScopedDependency;
 
 	}
 

--- a/Tests/SignalR.Extras.Autofac.Test/Stubs/GenericLifetimeHubStub.cs
+++ b/Tests/SignalR.Extras.Autofac.Test/Stubs/GenericLifetimeHubStub.cs
@@ -7,14 +7,16 @@ namespace SignalR.Extras.Autofac.Test.Stubs
 	public class GenericLifetimeHubStub : LifetimeHub<IHubClientStub>
 	{
 
-		public GenericLifetimeHubStub(ScopedObjectStub dep1, SingletonObjectStub dep2)
+		public GenericLifetimeHubStub(ScopedObjectStub dep1, SingletonObjectStub dep2, RequestScopedObjectStub dep3)
 		{
 			ScopedDependency = dep1;
 			SingletonDependency = dep2;
+			RequestScopedDependency = dep3;
 		}
 
 		public readonly ScopedObjectStub ScopedDependency;
 		public readonly SingletonObjectStub SingletonDependency;
+		public readonly RequestScopedObjectStub RequestScopedDependency;
 
 	}
 

--- a/Tests/SignalR.Extras.Autofac.Test/TestHelper.cs
+++ b/Tests/SignalR.Extras.Autofac.Test/TestHelper.cs
@@ -21,6 +21,7 @@ namespace SignalR.Extras.Autofac.Test
 			//Register stub dependencies for the hubs
 			builder.RegisterType<ScopedObjectStub>().InstancePerLifetimeScope();
 			builder.RegisterType<SingletonObjectStub>().SingleInstance();
+			builder.RegisterType<RequestScopedObjectStub>().InstancePerRequest(ScopeLifetimeTag.RequestLifetimeScopeTag);
 
 			//Register our LifetimeHubs
 			builder.RegisterType<DynamicLifetimeHubStub>().ExternallyOwned();


### PR DESCRIPTION
This pull request adds a tag that is used when creating the hub's lifetime scope. Dependencies can be registered using the InstancePerRequest method with the RequestLifetimeScopeTag property in the ScopeLifetimeTag class. It is backwards compatible with existing dependency registrations.
